### PR TITLE
feat: is adding breakpoint tokens

### DIFF
--- a/designTokens/breakpoint.js
+++ b/designTokens/breakpoint.js
@@ -1,0 +1,61 @@
+/* eslint-disable sort-keys */
+module.exports = {
+  zero: {
+    min: {
+      value: 0
+    },
+    max: {
+      value: 359
+    }
+  },
+  micro: {
+    min: {
+      value: 360
+    },
+    max: {
+      value: 599
+    }
+  },
+  small: {
+    min: {
+      value: 600
+    },
+    max: {
+      value: 839
+    }
+  },
+  medium: {
+    min: {
+      value: 840
+    },
+    max: {
+      value: 1023
+    }
+  },
+  large: {
+    min: {
+      value: 1024
+    },
+    max: {
+      value: 1279
+    }
+  },
+  wide: {
+    min: {
+      value: 1280
+    },
+    max: {
+      value: 1439
+    }
+  },
+  ultra: {
+    min: {
+      value: 1440
+    },
+    max: {
+      value: 2579
+    }
+  }
+};
+
+/* eslint-enable sort-keys */

--- a/designTokens/index.js
+++ b/designTokens/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+  breakpoint: require('./breakpoint'),
   color: require('./color'),
   spacings: require('./spacings')
 };


### PR DESCRIPTION
I took over the definitions from immo since they are used in the current design. Output will look like this:
$breakpoint-zero-min: 0;
$breakpoint-zero-max: 359;
$breakpoint-micro-min: 360;
$breakpoint-micro-max: 599;
$breakpoint-small-min: 600;
$breakpoint-small-max: 839;
$breakpoint-medium-min: 840;
$breakpoint-medium-max: 1023;
$breakpoint-large-min: 1024;
$breakpoint-large-max: 1279;
$breakpoint-wide-min: 1280;
$breakpoint-wide-max: 1439;
$breakpoint-ultra-min: 1440;
$breakpoint-ultra-max: 2579;