### PR TITLE
refactor: remove less output

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,6 @@ lyne-design-tokens/
     │    ├── tokens.cjs                             # Flat commonjs file
     │    ├── tokens.d.ts                            # Flat type declaration
     │    └── tokens.json                            # Flat .json file
-    ├── less/
-    │    ├── sbb-variables.less                     # `sbb-` prefixed Less variables (converted to `rem`)
-    │    └── variables.less                         # Less variables
     └── scss/
          ├── sbb-variables_css--placeholder.scss    # `sbb-` prefixed CSS variables with Sass placeholder selector (%) (converted to `rem`)
          ├── sbb-variables.scss                     # `sbb-` prefixed Sass variables (converted to `rem`)

--- a/config.ts
+++ b/config.ts
@@ -146,37 +146,6 @@ export const config: Config = {
       transformGroup: 'js',
       transforms: ['attribute/cti', 'name/cti/kebab', 'color/css'],
     },
-    less: {
-      buildPath: 'dist/less/',
-      files: [
-        {
-          destination: 'variables.less',
-          format: 'less/variables',
-        },
-      ],
-      transformGroup: 'less',
-      transforms: ['attribute/cti', 'name/cti/kebab', 'time/seconds', 'content/icon', 'color/css'],
-    },
-    lessPrefix: {
-      buildPath: 'dist/less/',
-      prefix: 'sbb',
-      files: [
-        {
-          destination: 'sbb-variables.less',
-          format: 'less/variables',
-        },
-      ],
-      transformGroup: 'less',
-      transforms: [
-        'attribute/cti',
-        'name/cti/kebab',
-        'time/seconds',
-        'content/icon',
-        'color/css',
-        'size/pxToRem',
-        'size/rem',
-      ],
-    },
     scss: {
       buildPath: 'dist/scss/',
       files: [

--- a/package.json
+++ b/package.json
@@ -56,8 +56,7 @@
       "node": "./dist/js/sbb-tokens.mjs",
       "default": "./dist/js/sbb-tokens.mjs",
       "require": "./dist/js/sbb-tokens.cjs",
-      "sass": "./dist/scss/sbb-variables.scss",
-      "less": "./dist/less/sbb-variables.less"
+      "sass": "./dist/scss/sbb-variables.scss"
     },
     "./dist/js/*": {
       "default": "./dist/js/*"
@@ -67,9 +66,6 @@
     },
     "./dist/scss/*": {
       "sass": "./dist/scss/*"
-    },
-    "./dist/less/*": {
-      "less": "./dist/less/*"
     }
   },
   "prettier": {


### PR DESCRIPTION
We have no requirement/demand for less. This also helps us reduce potential fragmentation.