### PR TITLE
refactor: use "SBB" instead of "SBBWeb" as font-family

### DIFF
--- a/designTokens/typo.ts
+++ b/designTokens/typo.ts
@@ -11,7 +11,7 @@ const attributes = (): Partial<DesignToken> => ({
 
 export const typo: DesignTokens = {
   fontFamily: {
-    value: '"SBBWeb", "Helvetica Neue", Helvetica, Arial, sans-serif',
+    value: '"SBB", "Helvetica Neue", Helvetica, Arial, sans-serif',
   },
   letterSpacing: {
     titles: {


### PR DESCRIPTION
BREAKING CHANGE: font-family was renamed from "SBBWeb" to "SBB"